### PR TITLE
Move server back to subdomain

### DIFF
--- a/src/assets/constants.js
+++ b/src/assets/constants.js
@@ -1,1 +1,1 @@
-export const rootServerUrl = 'https://guide-api.fly.dev';
+export const rootServerUrl = 'https://api.vomad.guide';


### PR DESCRIPTION
- feat: change root server url back to api.vomad.guide
